### PR TITLE
Use uuid instead of continent name for routes

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,12 +18,12 @@ app.use(cors());
 app.get('/', (req, res) => res.json(allRegionsData));
 
 // Return data for each region
-app.get('/asia', (req, res) => res.json(asiaData));
-app.get('/africa', (req, res) => res.json(africaData));
-app.get('/latin-america', (req, res) => res.json(latinAmericaData));
-app.get('/europe', (req, res) => res.json(europeData));
-app.get('/northern-america', (req, res) => res.json(northernAmericaData));
-app.get('/oceania', (req, res) => res.json(oceaniaData));
+app.get('/bbf0577d-2cec-44e8-a8c7-a394c2fcca99', (req, res) => res.json(asiaData));
+app.get('/46d44cfa-1781-4afd-89b7-e760af80e3b6', (req, res) => res.json(africaData));
+app.get('/da57f7de-7c58-44b5-8052-f27f5daa1b07', (req, res) => res.json(latinAmericaData));
+app.get('/3ba371eb-245a-4470-a465-85ded14872e0', (req, res) => res.json(europeData));
+app.get('/cc7e48b7-c558-42dd-a889-d80a0ff9a377', (req, res) => res.json(northernAmericaData));
+app.get('/11d94121-dd2c-47ee-a446-b3ddd61fa31a', (req, res) => res.json(oceaniaData));
 
 // 404 handler for non-matching routes
 app.use((req, res) => {


### PR DESCRIPTION
This pull request replaces continent names in the Express.js routes with unique UUIDs to guarantee unique URLs.